### PR TITLE
[rvbacktrace] 修复finsh命令直接调会hardfault的问题

### DIFF
--- a/src/rv_backtrace_fno.c
+++ b/src/rv_backtrace_fno.c
@@ -135,5 +135,9 @@ void rvbacktrace_fno(int (*print_func)(const char *fmt, ...))
     print_func("\r\n");
 }
 
-MSH_CMD_EXPORT_ALIAS(rvbacktrace_fno, rv_backtrace_all, backtrace all threads);
+void rv_backtrace_func(void)
+{
+    rvbacktrace_fno(BACKTRACE_PRINTF);
+}
+MSH_CMD_EXPORT_ALIAS(rv_backtrace_func, rv_backtrace_all, backtrace all threads);
 #endif /* BACKTRACE_USE_FP */


### PR DESCRIPTION
这里rvbacktrace_fno需要参数，但是finsh没有传参，会导致hardfault。